### PR TITLE
version 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-<div align="center"><img width="250px" src="public/imoji-editor-symbol.svg"></div>
+<div align="center"><img width="250px" src="https://github.com/medistream-team/imoji-editor/raw/develop/public/imoji-editor-symbol.svg"></div>
 <h1 align="center">✨ imoji Editor</h1>
 <p align="center">
 The image editor with a feature that you can add stickers to images!
 </p>
 <p align="center">
-<img src="https://img.shields.io/static/v1?label=version&message=0.1.0&color=red">
+<img src="https://img.shields.io/npm/v/imoji-editor?color=red">
 <img src="https://img.shields.io/static/v1?label=javascript&message=ES6&color=yellow">
 <img src="https://img.shields.io/static/v1?label=vue&message=2.x&color=green">
 <img src="https://img.shields.io/static/v1?label=license&message=MIT,CC&color=blue">
 </p>
 <p align="center">
-<img width="250px" src="public/editor2.gif">
+<img width="250px" src="https://github.com/medistream-team/imoji-editor/raw/master/public/editor2.gif">
 </p>
 
 ## Documentation
@@ -69,7 +69,8 @@ Use this prop to use sticker images what you want.
   >
   > Although Imoji is open source, the Medigi character's copyright is subject to the following:
   >
-  > ![](public/by-nc-nd.svg)  
+  > <img src="https://github.com/medistream-team/imoji-editor/raw/master/public/by-nc-nd.svg">
+  >
   > ©Medistream 2021. All right reserved.
 
 ### error-message
@@ -128,7 +129,7 @@ Please set width, height that fit with Modal's like this.
 If you want to change the target image to another image, just click image icon button and select new image.
 
 <p align="center">
-<img width="250px" src="public/change.gif">
+<img width="250px" src="https://github.com/medistream-team/imoji-editor/raw/master/public/change.gif">
 </p>
 
 ### Free Crop
@@ -191,7 +192,7 @@ this.photoCanvas.zoom(-0.1); // zoom out 10%
 User can move image to crop more easily by drag or touch (mobile) ONLY when move button is clicked. Move icon button is ONLY supported during crop mode.
 
 <p align="center">
-<img width="250px" src="public/move.gif">
+<img width="250px" src="https://github.com/medistream-team/imoji-editor/raw/master/public/move.gif">
 </p>
 
 ```jsx
@@ -227,7 +228,7 @@ this.stickerCanvas.addSticker(src, [options]);
 User can delete sticker by clicking trash can icon button. It will delete activate(=clicked by user) sticker one by one.
 
 <p align="center">
-<img width="250px" src="public/removeone.gif">
+<img width="250px" src="https://github.com/medistream-team/imoji-editor/raw/master/public/removeone.gif">
 </p>
 
 ```jsx

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imoji-editor",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build ./src/index.js --target lib",

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -61,7 +61,7 @@
         </button>
       </div>
     </template>
-    <template #toolBar="{photoCanvas, layout, zoom, rotate, flip, clearCrop}">
+    <template #toolBar="{photoCanvas, layout, zoom, rotate, flip}">
       <div v-if="layout === 'tool-bar'" class="tool-bar">
         <div v-show="isCropMode" class="ratio-crop-tool-bar">
           <button

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -61,7 +61,7 @@
         </button>
       </div>
     </template>
-    <template #toolBar="{photoCanvas, layout, zoom, rotate, clearCrop}">
+    <template #toolBar="{photoCanvas, layout, zoom, rotate, flip, clearCrop}">
       <div v-if="layout === 'tool-bar'" class="tool-bar">
         <div v-show="isCropMode" class="ratio-crop-tool-bar">
           <button
@@ -127,17 +127,11 @@
             <rotate-left />
           </button>
 
-          <button
-            class="tool-bar-button"
-            @click="photoCanvas.flip('X'), clearCrop()"
-          >
+          <button class="tool-bar-button" @click="flip('X')">
             <flip-horizontal />
           </button>
 
-          <button
-            class="tool-bar-button"
-            @click="photoCanvas.flip('Y'), clearCrop()"
-          >
+          <button class="tool-bar-button" @click="flip('Y')">
             <flip-vertical />
           </button>
         </div>

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -277,7 +277,6 @@ export default {
           this.crop();
           this.zoomCount = 0;
         }
-        //To Do : offCroppable emit이 두 번씩 발생 중인 현상 고치기
         this.photoCanvas.setDragMode('none');
         this.clearCrop();
       }

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -42,7 +42,6 @@
         :zoom="zoom"
         :rotate="rotate"
         :flip="flip"
-        :clear-crop="clearCrop"
       ></slot>
       <slot
         name="stickerToolBar"

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -41,6 +41,7 @@
         :layout="layout"
         :zoom="zoom"
         :rotate="rotate"
+        :flip="flip"
         :clear-crop="clearCrop"
       ></slot>
       <slot
@@ -161,10 +162,8 @@ export default {
       this.photoCanvas.changeImage(this.uploadedImageSrc);
       this.setPhotoCanvasSize();
     },
-    async setPhotoCanvasSize(isFirstLoading = true) {
-      const [width, height] = await this.photoCanvas.getPhotoCanvasSize(
-        isFirstLoading
-      );
+    async setPhotoCanvasSize() {
+      const [width, height] = await this.photoCanvas.getPhotoCanvasSize();
 
       this.$set(this.photoCanvasSize, 0, width);
       this.$set(this.photoCanvasSize, 1, height);
@@ -187,6 +186,7 @@ export default {
       this.photoCanvas.zoom(x);
     },
     rotate(sign) {
+      this.photoCanvas.setDragMode('none');
       this.photoCanvas.rotate(sign);
       const [width, height] = this.photoCanvas.getRotatedCanvasSize();
       this.$set(this.photoCanvasSize, 0, width);
@@ -194,9 +194,15 @@ export default {
       this.resizeStickerCanvas();
       this.clearCrop();
     },
+    flip(direction) {
+      this.photoCanvas.setDragMode('none');
+      this.photoCanvas.flip(direction);
+      this.clearCrop();
+    },
     reset() {
       if (this.photoCanvas) {
         this.photoCanvas.changeImage(this.initImageSrc);
+        this.photoCanvas.setDragMode('none');
         this.clearCrop();
         this.$refs.uploadedPhoto.addEventListener(
           'load',

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -148,9 +148,6 @@ export default {
       this.uploadedImageSrc = URL.createObjectURL(e.target.files[0]);
       this.initImageSrc = URL.createObjectURL(e.target.files[0]);
 
-      this.changeImage();
-    },
-    changeImage() {
       if (!this.photoCanvas) {
         this.photoCanvas = new PhotoEditor('#user-photo', {
           minContainerHeight: this.height,
@@ -158,10 +155,11 @@ export default {
         });
       }
 
-      if (this.photoCanvas) {
-        this.photoCanvas.changeImage(this.uploadedImageSrc);
-        this.setPhotoCanvasSize();
-      }
+      this.changeImage();
+    },
+    changeImage() {
+      this.photoCanvas.changeImage(this.uploadedImageSrc);
+      this.setPhotoCanvasSize();
     },
     async setPhotoCanvasSize(isFirstLoading = true) {
       const [width, height] = await this.photoCanvas.getPhotoCanvasSize(
@@ -262,9 +260,6 @@ export default {
       this.hide = false;
       this.layout = 'sticker-tool-bar';
 
-      this.crop();
-      this.photoCanvas.setDragMode('none');
-
       if (!this.stickerCanvas) {
         this.setPhotoCanvasSize();
         const [width, height] = this.photoCanvasSize;
@@ -272,14 +267,12 @@ export default {
       }
 
       if (this.photoCanvas) {
-        if (this.zoomCount > 0) {
-          this.photoCanvas.zoom(-1 * this.zoomCount);
+        if (this.zoomCount !== 0) {
+          this.crop();
+          this.zoomCount = 0;
         }
-        if (this.zoomCount < 0) {
-          this.photoCanvas.zoom(Math.abs(this.zoomCount));
-        }
-        this.zoomCount = 0;
         //To Do : offCroppable emit이 두 번씩 발생 중인 현상 고치기
+        this.photoCanvas.setDragMode('none');
         this.clearCrop();
       }
 

--- a/src/js/ImojiEditor.js
+++ b/src/js/ImojiEditor.js
@@ -32,17 +32,9 @@ export class PhotoEditor {
     this.cropper.setDragMode(mode);
   }
 
-  getPhotoCanvasSize(isFirstLoading = true) {
+  getPhotoCanvasSize() {
     return new Promise((resolve, reject) => {
       try {
-        if (!isFirstLoading) {
-          const target = document.getElementsByClassName('cropper-canvas');
-          const width = target[0].style.width;
-          const height = target[0].style.height;
-          resolve([parseInt(width), parseInt(height)]);
-          return;
-        }
-
         this.userImage.addEventListener(
           'ready',
           () => {


### PR DESCRIPTION
## 수정사항
### 사진 로드 후 바로 스티커모드 진입시 에러가 발생했던 문제
- 원래 사진 로드 후 edit 모드 진입시 cropper 캔버스가 생기도록 하는 것에서 사진 로드시 바로 cropper 캔버스가 생기게끔 수정했었는데, cropper가 완전히 다 생기는 것을 기다리지 않고 스티커 모드 진입시의 코드들이 실행되어 발생한 에러로 의심됩니다. 이미지 로딩이 완료되길 기다리는 것과는 관련이 없었습니다.
- 게다가 zoom in / zoom out 시 변하는 이미지의 영역을 스티커 캔버스가 따라갈 수 있도록 스티커 모드 진입시 무조건 crop이 되게 했었는데, **위의 에러가 발생하기도 하고 큰 이미지 특히 png가 아닌 이미지의 경우 crop시 지연이 발생하여 zoom이 발생했을 때만 crop하고 넘어가게끔 수정했습니다.** 
png 이미지는 지연이 발생하지 않아서 아마도 png가 아닌 파일을 crop하여 png로 변환하고 다시 그려내느라 지연이 발생한 것 아닐까 의심이 되는데... 이 부분은 좀 더 확인해보고 수정할 예정입니다.

### flip시 drag mode가 crop mode인 문제
drag crop mode는 crop 박스가 활성화 되어있을 때만 설정되어 있어야 하는데 flip 시에도 설정되어있어 이 부분을 변경했습니다.

### 기타
- 불필요한 코드를 삭제했습니다. (isFirstLoading boolean 변수를 핸들링해주는 코드가 존재하지 않는데 쓰이고 있어서 삭제, 완료된 todo 주석 삭제)
- npm에서 리드미의 이미지가 깨지길래 경로를 수정했습니다.
- 버전을 0.1.4로 업데이트했습니다.
