### PR TITLE
version 0.1.5 : fix lazy crop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 The image editor with a feature that you can add stickers to images!
 </p>
 <p align="center">
-<img src="https://img.shields.io/static/v1?label=version&message=0.1.0&color=red">
+<img src="https://img.shields.io/npm/v/imoji-editor?color=red">
 <img src="https://img.shields.io/static/v1?label=javascript&message=ES6&color=yellow">
 <img src="https://img.shields.io/static/v1?label=vue&message=2.x&color=green">
 <img src="https://img.shields.io/static/v1?label=license&message=MIT,CC&color=blue">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imoji-editor",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build ./src/index.js --target lib",
@@ -29,6 +29,11 @@
     "dist/img/*.*"
   ],
   "main": "dist/imoji-editor.umd.min.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/medistream-team/imoji-editor"
+  },
   "dependencies": {
     "vue": "^2.6.11"
   },

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -166,10 +166,6 @@
           Sticker
         </button>
       </div>
-      <!-- 이미지 잘 저장되는지 테스트용 -->
-      <div id="testA">
-        <image id="testB" />
-      </div>
     </template>
   </imoji-editor-canvas>
 </template>
@@ -301,9 +297,6 @@ export default {
     },
     async done() {
       const resultImage = await this.$refs.Imoji.exportResultPhoto();
-      //이미지 잘 저장되는지 테스트용
-      const d = document.getElementById('testA');
-      d.appendChild(resultImage);
       this.$emit('done', resultImage);
     }
   }

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -19,7 +19,12 @@
         >
           <label>
             <file-image />
-            <input type="file" class="file" @change="onInputImage" />
+            <input
+              type="file"
+              class="file"
+              accept="image/jpeg, image/png"
+              @change="onInputImage"
+            />
           </label>
         </button>
 

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -166,6 +166,10 @@
           Sticker
         </button>
       </div>
+      <!-- 이미지 잘 저장되는지 테스트용 -->
+      <div id="testA">
+        <image id="testB" />
+      </div>
     </template>
   </imoji-editor-canvas>
 </template>
@@ -297,6 +301,9 @@ export default {
     },
     async done() {
       const resultImage = await this.$refs.Imoji.exportResultPhoto();
+      //이미지 잘 저장되는지 테스트용
+      const d = document.getElementById('testA');
+      d.appendChild(resultImage);
       this.$emit('done', resultImage);
     }
   }

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -131,6 +131,7 @@ export default {
           { once: true }
         );
       });
+
       loadImportedImage.then(() => {
         if (!this.photoCanvas) {
           this.photoCanvas = new PhotoEditor('#user-photo', {
@@ -147,6 +148,7 @@ export default {
     },
     onInputImage(e) {
       const { files } = e.target;
+
       this.uploadedImageSrc = URL.createObjectURL(files[0]);
       this.initImageSrc = URL.createObjectURL(files[0]);
       this.imgType = files[0].type;

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -101,7 +101,8 @@ export default {
       initImageSrc: '',
       zoomCount: 0,
       layout: '',
-      hide: true
+      hide: true,
+      imgType: ''
     };
   },
   watch: {
@@ -145,8 +146,10 @@ export default {
       });
     },
     onInputImage(e) {
-      this.uploadedImageSrc = URL.createObjectURL(e.target.files[0]);
-      this.initImageSrc = URL.createObjectURL(e.target.files[0]);
+      const { files } = e.target;
+      this.uploadedImageSrc = URL.createObjectURL(files[0]);
+      this.initImageSrc = URL.createObjectURL(files[0]);
+      this.imgType = files[0].type;
 
       if (!this.photoCanvas) {
         this.photoCanvas = new PhotoEditor('#user-photo', {
@@ -218,28 +221,30 @@ export default {
       }
     },
     crop() {
-      this.photoCanvas.finishCrop();
+      this.photoCanvas.finishCrop(this.imgType);
       this.setPhotoCanvasSize();
     },
     async exportResultPhoto() {
       // case 1. only Edit
       if (!this.stickerCanvas && this.photoCanvas) {
-        return this.photoCanvas.exportResultPhoto();
+        return this.photoCanvas.exportOnlyImage(this.imgType);
       }
 
       // case 2. only Sticker
       if (!this.photoCanvas && this.stickerCanvas) {
         const width = this.photoCanvas.getNaturalSize()[0];
-        return await this.photoCanvas.exportResultPhoto(
-          this.stickerCanvas.saveStickerImage(width)
+        return await this.photoCanvas.exportWithSticker(
+          this.stickerCanvas.saveStickerImage(width),
+          this.imgType
         );
       }
 
       // case 3. Edit & Sticker
       if (this.photoCanvas && this.stickerCanvas) {
         const width = this.photoCanvas.getNaturalSize()[0];
-        return await this.photoCanvas.exportResultPhoto(
-          this.stickerCanvas.saveStickerImage(width)
+        return await this.photoCanvas.exportWithSticker(
+          this.stickerCanvas.saveStickerImage(width),
+          this.imgType
         );
       }
     },

--- a/src/js/ImojiEditor.js
+++ b/src/js/ImojiEditor.js
@@ -139,7 +139,7 @@ export class PhotoEditor {
   }
 
   /**
-   * Export result photo image object
+   * Export result photo image object when edited with sticker
    * @param {Image} stickerImage - Image Object of sticker canvas result
    * @param {string} imgType - same as original image type
    * @returns Promise (for Image Object)
@@ -163,7 +163,7 @@ export class PhotoEditor {
   }
 
   /**
-   *
+   * Export result photo image object when only edited
    * @param {string} imgType
    * @returns Image Object
    */

--- a/src/js/ImojiEditor.js
+++ b/src/js/ImojiEditor.js
@@ -75,20 +75,14 @@ export class PhotoEditor {
   }
 
   /**
-   *
-   * @param {string} imgType
+   * Crop Image
+   * @param {string} imgType - same as original image type
    */
   finishCrop(imgType) {
     const canvas = this.cropper.getCroppedCanvas();
     const croppedImgSrc = canvas.toDataURL(imgType);
     this.cropper.replace(croppedImgSrc);
   }
-
-  // finishCrop() {
-  //   const canvas = this.cropper.getCroppedCanvas();
-  //   const croppedImgSrc = canvas.toDataURL();
-  //   this.cropper.replace(croppedImgSrc);
-  // }
 
   /**
    * Set two number for calculate ratio (x/y) of crop box

--- a/src/js/ImojiEditor.js
+++ b/src/js/ImojiEditor.js
@@ -74,11 +74,21 @@ export class PhotoEditor {
     this.cropper.destroy();
   }
 
-  finishCrop() {
+  /**
+   *
+   * @param {string} imgType
+   */
+  finishCrop(imgType) {
     const canvas = this.cropper.getCroppedCanvas();
-    const croppedImgSrc = canvas.toDataURL('image/png');
+    const croppedImgSrc = canvas.toDataURL(imgType);
     this.cropper.replace(croppedImgSrc);
   }
+
+  // finishCrop() {
+  //   const canvas = this.cropper.getCroppedCanvas();
+  //   const croppedImgSrc = canvas.toDataURL();
+  //   this.cropper.replace(croppedImgSrc);
+  // }
 
   /**
    * Set two number for calculate ratio (x/y) of crop box
@@ -131,31 +141,37 @@ export class PhotoEditor {
   /**
    * Export result photo image object
    * @param {Image} stickerImage - Image Object of sticker canvas result
-   * @returns Image Object \\ Promise (Image Object)
+   * @param {string} imgType - same as original image type
+   * @returns Promise (for Image Object)
    */
-  exportResultPhoto(stickerImage) {
+  exportWithSticker(stickerImage, imgType) {
     const canvas = this.cropper.getCroppedCanvas();
-    const editedPhoto = new Image();
-    editedPhoto.src = canvas.toDataURL('image/png');
-    //return Image Object
-    if (!stickerImage) return editedPhoto;
-
-    //add sticker image on photo canvas
     const context = canvas.getContext('2d');
 
-    let loadResultPhoto = new Promise(resolve => {
+    let loadResultImage = new Promise(resolve => {
       stickerImage.onload = () => {
         context.drawImage(stickerImage, 0, 0);
         resolve(canvas);
       };
     });
 
-    //return promise
-    return loadResultPhoto.then(res => {
+    return loadResultImage.then(res => {
       const withStickerImage = new Image();
-      withStickerImage.src = res.toDataURL('image/png');
+      withStickerImage.src = res.toDataURL(imgType);
       return withStickerImage;
     });
+  }
+
+  /**
+   *
+   * @param {string} imgType
+   * @returns Image Object
+   */
+  exportOnlyImage(imgType) {
+    const canvas = this.cropper.getCroppedCanvas();
+    const editedPhoto = new Image();
+    editedPhoto.src = canvas.toDataURL(imgType);
+    return editedPhoto;
   }
 
   /**

--- a/src/js/ImojiEditor.js
+++ b/src/js/ImojiEditor.js
@@ -169,9 +169,9 @@ export class PhotoEditor {
    */
   exportOnlyImage(imgType) {
     const canvas = this.cropper.getCroppedCanvas();
-    const editedPhoto = new Image();
-    editedPhoto.src = canvas.toDataURL(imgType);
-    return editedPhoto;
+    const editedImage = new Image();
+    editedImage.src = canvas.toDataURL(imgType);
+    return editedImage;
   }
 
   /**


### PR DESCRIPTION
* 두 분도 아셔야 하는 부분인 것 같아서 알람 차원으로 request했습니다 !

### 수정 사항
- 문제점 : 용량에 관계없이 png가 아닌 파일을 편집시 crop이 오래걸렸음
- 의심 : crop할 때 원본 이미지의 확장자가 뭐든간에 무조건 다 png로 설정해서 그런건 아닐까?
- 확인 결과
  - 속도가 개선된 것을 보면 영향이 있던 것은 맞으나, 완전히 해결되지는 않았습니다.
  - 무조건 png로 크롭/저장되게 했던 것에서 원본 이미지의 확장자를 따라가도록 수정했습니다.
  - 단, 외부에서 들어오는 이미지의 경우 요런게 들어오면 확장자를 알 수 없는 것 같아서... 외부에서 들어오는 이미지는 원래대로 png로만 되게 되어있습니다. 이거 말고는 외부에서 뭐가 어떻게 들어올지 예상이 안되네요 ㅜ 만일 확장자를 알 수 있는 방법이 있다면 수정하는게 좋을 것 같습니다. 
![sample](https://user-images.githubusercontent.com/76927618/125174434-6f4b1100-e200-11eb-8c0e-b45c4e3f2f8d.png)
 
  - 그 결과 크롭 속도가 약 1초 가량 빨라지긴 했습니다...?🤔😂🤦‍♀️. 
    육안으로는 빨라진건지 느려진건지 모르겠어서 스톱워치로 재보니까 아래와 같이 찍히더라구요.
  - 1초가 유의미한지는 사실 잘 모르겠지만 그래도 없는 것보다는 나을 것 같아서 업데이트하고자 pr올립니다.
  - 이 이상으로 더 빨리 할 수 있는지는 모르겠습니다. 일단 [cropper 제작자가 만든 에디터](https://fengyuanchen.github.io/photo-editor/)에서 동일한 조건으로 테스트 해봤을 때도 속도가 저희랑 비슷하네요 ㅎ...
  - 테스트 조건은 3mb의 jpeg 파일입니다.

- 테스트 관련 이미지
  - 좌: 기존 크롭 속도  | 우: 수정한 속도 
  - <img width="350px" src="https://user-images.githubusercontent.com/76927618/125173259-54c16980-e1f9-11eb-9b47-725447c1c738.gif">  <img width="350px" src="https://user-images.githubusercontent.com/76927618/125173277-6e62b100-e1f9-11eb-80e3-bf04a61c3eaf.gif">
  - 스톱워치 비교
  - <img width="350px" src="https://user-images.githubusercontent.com/76927618/125173529-ccdc5f00-e1fa-11eb-8f9e-8c0a8d45f62f.png"> <img width="350px" src="https://user-images.githubusercontent.com/76927618/125173526-cb129b80-e1fa-11eb-9f01-249d1389d6fb.png"> 

### 기타 사항
- 스티커 편집까지 하고 저장시 속도가 느린 것은 확장자 문제가 아니라 아무래도 그냥 크롭만 하는 것보다는 할 게 더 많기도 하고,
  코드가 속도면에서 비효율적이라서 느린거 아닐까? 하는 생각이 듭니다 ㅎㅎ...😅 확인해보겠습니다.