### PR TITLE
Feature/modify ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Vue.use(ImojiEditor);
 <imoji-editor
     :default-image="importedImage"
     :sticker-images="stickerImages"
-    :error-message="'please choose image first'"
+    :sticker-reset-message="'All stickers are deleted when you edit the photo'"
     :width="600"
     :height="480"
     @done="image => {
@@ -73,11 +73,11 @@ Use this prop to use sticker images what you want.
   >
   > ©Medistream 2021. All right reserved.
 
-### error-message
+### sticker-reset-message
 
-Use this prop to write an error message to show if the user clicks `edit` or `sticker` button even if there is no image to edit.
+Use this prop to change the warning message that the stickers will be reset when the `Edit` button is clicked.
 
-- Default : korean
+- Default : `All stickers are deleted when you edit the photo`
 - Type : string
 
 ### width, height

--- a/docs/options/README.md
+++ b/docs/options/README.md
@@ -4,7 +4,7 @@
 <imoji-editor
     :default-image="importedImage"
     :sticker-images="stickerImages"
-    :error-message="'please choose image first'"
+    :sticker-reset-message="'All stickers are deleted when you edit the photo'"
     :width="600"
     :height="480"
     @done="image => {
@@ -38,11 +38,11 @@ Use this prop to use sticker images what you want.
   >
   > ©Medistream 2021. All right reserved.
 
-## error-message
+## sticker-reset-message
 
-Use this prop to write an error message to show if the user clicks `edit` or `sticker` button even if there is no image to edit.
+Use this prop to change the warning message that the stickers will be reset when the `Edit` button is clicked.
 
-- Default : korean
+- Default : `All stickers are deleted when you edit the photo`
 - Type : string
 
 ## width, height

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build ./src/index.js --target lib",
+    "build:watch": "vue-cli-service build ./src/index.js --target lib --watch",
     "lint": "vue-cli-service lint",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs"

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -451,8 +451,8 @@ export default {
   grid-auto-flow: column;
   justify-content: space-around;
   width: 100%;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  padding-top: 5px;
+  padding-bottom: 6px;
   size: 1.938rem;
   z-index: 2;
   z-index: 2;

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -357,10 +357,18 @@ export default {
 }
 
 .controller-bar-button {
-  background-color: transparent;
-  color: aliceblue;
+  position: relative;
+  width: 42px;
+  height: 42px;
+  border-radius: 28px;
   border-style: none;
+  background-color: transparent;
   cursor: pointer;
+  transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
+}
+
+.controller-bar-button:not(:disabled):hover {
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 .controller-bar-button label {
@@ -370,10 +378,6 @@ export default {
 .controller-bar-button:disabled {
   color: grey;
   cursor: not-allowed;
-}
-
-.controller-bar-button:hover {
-  color: grey;
 }
 
 .tool-bar {
@@ -393,10 +397,18 @@ export default {
 }
 
 .tool-bar-button {
-  background-color: transparent;
-  color: white;
+  border-radius: 28px;
+  padding: 5px;
   border-style: none;
+  color: white;
+  background-color: transparent;
+  line-height: 0;
   cursor: pointer;
+  transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
+}
+
+.tool-bar-button:hover {
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 .tool-navigation-wrapper {
@@ -428,8 +440,8 @@ export default {
   cursor: not-allowed;
 }
 
-.tool-navigation-button:hover {
-  color: grey;
+.tool-navigation-button:not(:disabled):hover {
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 .sticker-tool-bar {
@@ -448,7 +460,7 @@ export default {
   display: flex;
   justify-content: space-around;
   width: 100%;
-  padding-top: 10px;
+  padding-top: 5px;
   padding-bottom: 10px;
   border-style: none;
   z-index: 2;
@@ -456,15 +468,18 @@ export default {
 
 .ratio-crop-tool-bar-button {
   height: 1.938rem;
+  padding: 5px;
+  border-radius: 28px;
+  border-style: none;
   color: white;
   background-color: transparent;
   font-size: 1rem;
-  border-style: none;
   cursor: pointer;
+  transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .ratio-crop-tool-bar-button:hover {
-  color: grey;
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 img.image-sticker {

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -148,11 +148,14 @@
         />
       </div>
     </template>
-    <template #toolNavigation="{openImageEditor, openStickerEditor}">
+    <template
+      #toolNavigation="{openImageEditor, openStickerEditor, uploadedImageSrc}"
+    >
       <div class="tool-navigation-wrapper">
         <button
           class="tool-navigation-button"
           title="Photo"
+          :disabled="uploadedImageSrc ? false : true"
           @click="openImageEditor"
         >
           Photo
@@ -161,6 +164,7 @@
         <button
           class="tool-navigation-button"
           title="Emoji Sticker"
+          :disabled="uploadedImageSrc ? false : true"
           @click="openStickerEditor"
         >
           Emoji Sticker

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -35,21 +35,21 @@
           </button>
 
           <button
-            v-show="isCropMode"
-            class="controller-bar-button"
-            title="move"
-            @click="photoCanvas.setDragMode('move')"
-          >
-            <cursor-move />
-          </button>
-
-          <button
             class="controller-bar-button"
             title="reset"
             :disabled="uploadedImageSrc ? false : true"
             @click="reset"
           >
             <restore-icon />
+          </button>
+
+          <button
+            v-show="isCropMode"
+            class="controller-bar-button"
+            title="move"
+            @click="photoCanvas.setDragMode('move')"
+          >
+            <cursor-move />
           </button>
 
           <div v-if="layout === 'sticker-tool-bar'" class="delete-sticker">

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -324,16 +324,20 @@ export default {
 
 .controller-bar-wrapper {
   position: absolute;
+  z-index: 2;
   top: 0;
+  left: 0;
+  right: 0;
   display: flex;
   justify-content: space-around;
   align-items: center;
+  margin: 0 auto;
   width: 100%;
+  max-width: 800px;
   padding-top: 10px;
   padding-bottom: 10px;
   border: none;
   background: rgba(0, 0, 0, 0.1);
-  z-index: 2;
 }
 
 .controller-bar-button {

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -152,18 +152,18 @@
       <div class="tool-navigation-wrapper">
         <button
           class="tool-navigation-button"
-          title="edit"
+          title="Photo"
           @click="openImageEditor"
         >
-          Edit
+          Photo
         </button>
 
         <button
           class="tool-navigation-button"
-          title="sticker"
+          title="Emoji Sticker"
           @click="openStickerEditor"
         >
-          Sticker
+          Emoji Sticker
         </button>
       </div>
     </template>

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -172,12 +172,13 @@
       </div>
     </template>
     <template
-      #toolNavigation="{openImageEditor, openStickerEditor, uploadedImageSrc}"
+      #toolNavigation="{openImageEditor, openStickerEditor, uploadedImageSrc, layout}"
     >
       <div class="tool-navigation-wrapper">
         <button
           class="tool-navigation-button"
           title="Photo"
+          :class="layout === 'tool-bar' ? 'activated' : undefined"
           :disabled="uploadedImageSrc ? false : true"
           @click="openImageEditor"
         >
@@ -187,6 +188,7 @@
         <button
           class="tool-navigation-button"
           title="Emoji Sticker"
+          :class="layout === 'sticker-tool-bar' ? 'activated' : undefined"
           :disabled="uploadedImageSrc ? false : true"
           @click="openStickerEditor"
         >

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -452,6 +452,11 @@ export default {
 img.image-sticker {
   width: 1.938rem;
   cursor: pointer;
+  transition: transform 0.3s ease-in-out;
+}
+
+img.image-sticker:hover {
+  transform: scale(1.3);
 }
 
 i {

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -386,6 +386,8 @@ export default {
   border-radius: 28px;
   border-style: none;
   background-color: transparent;
+  color: white;
+  line-height: 0;
   cursor: pointer;
   transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
 }

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -12,63 +12,75 @@
       #controllerBar="{reset, stickerCanvas, onInputImage, crop, layout, photoCanvas, uploadedImageSrc}"
     >
       <div class="controller-bar-wrapper">
-        <button
-          class="controller-bar-button"
-          title="image upload"
-          accept="image/*"
-        >
-          <label>
-            <file-image />
-            <input type="file" class="file" @change="onInputImage" />
-          </label>
-        </button>
-
-        <button
-          v-show="isCropMode"
-          class="controller-bar-button"
-          title="move"
-          @click="photoCanvas.setDragMode('move')"
-        >
-          <cursor-move />
-        </button>
-
-        <button
-          class="controller-bar-button"
-          title="reset"
-          :disabled="uploadedImageSrc ? false : true"
-          @click="reset"
-        >
-          <restore-icon />
-        </button>
-
-        <div v-if="layout === 'sticker-tool-bar'" class="delete-sticker">
+        <div class="controller-bar-buttons-wrapper">
           <button
             class="controller-bar-button"
-            title="delete sticker"
-            @click="stickerCanvas.removeSticker()"
+            title="image upload"
+            @click="
+              e => {
+                e.target.querySelector('input[type=\'file\']') &&
+                  e.target.querySelector('input[type=\'file\']').click();
+              }
+            "
           >
-            <delete-icon />
+            <label>
+              <file-image />
+              <input
+                type="file"
+                accept="image/*"
+                class="file"
+                @change="onInputImage"
+              />
+            </label>
           </button>
-        </div>
 
-        <div v-if="layout === 'tool-bar'" class="complete-crop">
+          <button
+            v-show="isCropMode"
+            class="controller-bar-button"
+            title="move"
+            @click="photoCanvas.setDragMode('move')"
+          >
+            <cursor-move />
+          </button>
+
           <button
             class="controller-bar-button"
-            title="complete crop"
-            @click="crop"
+            title="reset"
+            :disabled="uploadedImageSrc ? false : true"
+            @click="reset"
           >
-            <check-icon />
+            <restore-icon />
+          </button>
+
+          <div v-if="layout === 'sticker-tool-bar'" class="delete-sticker">
+            <button
+              class="controller-bar-button"
+              title="delete sticker"
+              @click="stickerCanvas.removeSticker()"
+            >
+              <delete-icon />
+            </button>
+          </div>
+
+          <div v-if="layout === 'tool-bar'" class="complete-crop">
+            <button
+              class="controller-bar-button"
+              title="complete crop"
+              @click="crop"
+            >
+              <check-icon />
+            </button>
+          </div>
+
+          <button
+            class="controller-bar-button"
+            title="done"
+            :disabled="uploadedImageSrc ? false : true"
+            @click="done"
+          >
+            <download-icon />
           </button>
         </div>
-
-        <button
-          class="controller-bar-button"
-          title="done"
-          :disabled="uploadedImageSrc ? false : true"
-          @click="done"
-        >
-          <download-icon />
-        </button>
       </div>
     </template>
     <template #toolBar="{photoCanvas, layout, zoom, rotate, flip}">
@@ -328,16 +340,20 @@ export default {
   top: 0;
   left: 0;
   right: 0;
+  width: 100%;
+  padding: 10px 0px;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.controller-bar-buttons-wrapper {
+  position: relative;
+  top: 0;
   display: flex;
   justify-content: space-around;
   align-items: center;
   margin: 0 auto;
   width: 100%;
   max-width: 800px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  border: none;
-  background: rgba(0, 0, 0, 0.1);
 }
 
 .controller-bar-button {
@@ -397,12 +413,14 @@ export default {
   display: flex;
   justify-content: space-around;
   align-items: center;
-  margin: 10px auto;
-  size: 30px;
+  margin: 0 auto;
+  padding: 10px;
+  border-radius: 28px;
+  border-style: none;
   color: white;
   background-color: transparent;
-  border-style: none;
   cursor: pointer;
+  transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .tool-navigation-button:disabled {

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -357,35 +357,24 @@ export default {
       this.isCropMode = test;
     },
     async done() {
+      let resultImage;
+
       try {
-        const resultImage = await this.$refs.Imoji.exportResultPhoto();
-
-        if (this.$listeners.done) {
-          this.$emit('done', resultImage);
-          return;
-        }
-
-        const d = new Date();
-        const dateString = `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(
-          2,
-          '0'
-        )}-${`${d.getDate()}`.padStart(2, '0')}`;
-
-        const timeString = `${`${d.getHours()}`.padStart(
-          2,
-          '0'
-        )}:${`${d.getMinutes()}`.padStart(
-          2,
-          '0'
-        )}:${`${d.getSeconds()}`.padStart(2, '0')}`;
-
-        const anchorEl = document.createElement('a');
-        anchorEl.setAttribute('href', resultImage.src);
-        anchorEl.setAttribute('download', `${dateString} ${timeString}.jpeg`);
-        anchorEl.click();
+        resultImage = await this.$refs.Imoji.exportResultPhoto();
       } catch (error) {
         this.$emit('error', error);
+        return;
       }
+
+      if (this.$listeners.done) {
+        this.$emit('done', resultImage);
+        return;
+      }
+
+      const anchorEl = document.createElement('a');
+      anchorEl.setAttribute('href', resultImage.src);
+      anchorEl.setAttribute('download', `imoji_${new Date().toLocaleString()}`);
+      anchorEl.click();
     }
   }
 };

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -67,7 +67,12 @@
             <button
               class="controller-bar-button"
               title="complete crop"
-              @click="crop"
+              @click="
+                () => {
+                  crop();
+                  isCropMode = false;
+                }
+              "
             >
               <check-icon />
             </button>

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -2,7 +2,6 @@
   <imoji-editor-canvas
     ref="Imoji"
     :default-image="defaultImage"
-    :error-message="errorMessage"
     :sticker-reset-message="stickerResetMessage"
     :width="width"
     :height="height"
@@ -250,7 +249,7 @@ export default {
     stickerResetMessage: {
       type: String,
       required: false,
-      default: '스티커를 초기화 하시겠습니까?'
+      default: 'All stickers are deleted when you edit the photo'
     },
     choosePhoto: {
       type: Boolean,

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -392,21 +392,6 @@ export default {
   background-color: transparent;
   color: white;
   line-height: 0;
-  cursor: pointer;
-  transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
-}
-
-.controller-bar-button:not(:disabled):hover {
-  background-color: rgba(255, 255, 255, 0.2);
-}
-
-.controller-bar-button label {
-  cursor: pointer;
-}
-
-.controller-bar-button:disabled {
-  color: grey;
-  cursor: not-allowed;
 }
 
 .tool-bar {
@@ -432,12 +417,6 @@ export default {
   color: white;
   background-color: transparent;
   line-height: 0;
-  cursor: pointer;
-  transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
-}
-
-.tool-bar-button:hover {
-  background-color: rgba(255, 255, 255, 0.2);
 }
 
 .tool-navigation-wrapper {
@@ -460,16 +439,10 @@ export default {
   border-style: none;
   color: white;
   background-color: transparent;
-  cursor: pointer;
   transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
 }
 
-.tool-navigation-button:disabled {
-  color: grey;
-  cursor: not-allowed;
-}
-
-.tool-navigation-button:not(:disabled):hover {
+.tool-navigation-button.activated {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
@@ -503,22 +476,10 @@ export default {
   color: white;
   background-color: transparent;
   font-size: 1rem;
-  cursor: pointer;
-  transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
-}
-
-.ratio-crop-tool-bar-button:hover {
-  background-color: rgba(255, 255, 255, 0.2);
 }
 
 img.image-sticker {
   width: 1.938rem;
-  cursor: pointer;
-  transition: transform 0.3s ease-in-out;
-}
-
-img.image-sticker:hover {
-  transform: scale(1.3);
 }
 
 i {
@@ -526,7 +487,68 @@ i {
   font-size: 25px;
 }
 
-i:hover {
-  color: grey;
+/* apply hover effect only on PC */
+@media (hover: hover) {
+  .controller-bar-button {
+    cursor: pointer;
+    transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
+  }
+
+  .controller-bar-button label {
+    cursor: pointer;
+  }
+
+  .controller-bar-button:not(:disabled):hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .controller-bar-button:disabled {
+    color: grey;
+    cursor: not-allowed;
+  }
+
+  .tool-bar-button {
+    cursor: pointer;
+    transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
+  }
+
+  .tool-bar-button:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .tool-navigation-button {
+    cursor: pointer;
+  }
+
+  .tool-navigation-button:disabled {
+    color: grey;
+    cursor: not-allowed;
+  }
+
+  .tool-navigation-button:not(:disabled):hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .ratio-crop-tool-bar-button {
+    cursor: pointer;
+    transition: background-color 0.2s cubic-bezier(0.4, 0, 0.6, 1);
+  }
+
+  .ratio-crop-tool-bar-button:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  img.image-sticker {
+    cursor: pointer;
+    transition: transform 0.3s ease-in-out;
+  }
+
+  img.image-sticker:hover {
+    transform: scale(1.3);
+  }
+
+  i:hover {
+    color: grey;
+  }
 }
 </style>

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -74,6 +74,7 @@
           </div>
 
           <button
+            v-if="!isCropMode"
             class="controller-bar-button"
             title="done"
             :disabled="uploadedImageSrc ? false : true"

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -63,7 +63,7 @@
             </button>
           </div>
 
-          <div v-if="layout === 'tool-bar'" class="complete-crop">
+          <div v-if="layout === 'tool-bar' && isCropMode" class="complete-crop">
             <button
               class="controller-bar-button"
               title="complete crop"

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -14,6 +14,7 @@
       <div class="controller-bar-wrapper">
         <div class="controller-bar-buttons-wrapper">
           <button
+            v-if="choosePhoto"
             class="controller-bar-button"
             title="image upload"
             @click="
@@ -235,6 +236,11 @@ export default {
       type: String,
       required: false,
       default: '편집할 사진을 선택해주세요'
+    },
+    choosePhoto: {
+      type: Boolean,
+      required: false,
+      default: true
     },
     width: {
       type: Number,

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -322,31 +322,35 @@ export default {
       this.isCropMode = test;
     },
     async done() {
-      const resultImage = await this.$refs.Imoji.exportResultPhoto();
+      try {
+        const resultImage = await this.$refs.Imoji.exportResultPhoto();
 
-      if (this.$listeners.done) {
-        this.$emit('done', resultImage);
-        return;
+        if (this.$listeners.done) {
+          this.$emit('done', resultImage);
+          return;
+        }
+
+        const d = new Date();
+        const dateString = `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(
+          2,
+          '0'
+        )}-${`${d.getDate()}`.padStart(2, '0')}`;
+
+        const timeString = `${`${d.getHours()}`.padStart(
+          2,
+          '0'
+        )}:${`${d.getMinutes()}`.padStart(
+          2,
+          '0'
+        )}:${`${d.getSeconds()}`.padStart(2, '0')}`;
+
+        const anchorEl = document.createElement('a');
+        anchorEl.setAttribute('href', resultImage.src);
+        anchorEl.setAttribute('download', `${dateString} ${timeString}.jpeg`);
+        anchorEl.click();
+      } catch (error) {
+        this.$emit('error', error);
       }
-
-      const d = new Date();
-      const dateString = `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(
-        2,
-        '0'
-      )}-${`${d.getDate()}`.padStart(2, '0')}`;
-
-      const timeString = `${`${d.getHours()}`.padStart(
-        2,
-        '0'
-      )}:${`${d.getMinutes()}`.padStart(2, '0')}:${`${d.getSeconds()}`.padStart(
-        2,
-        '0'
-      )}`;
-
-      const anchorEl = document.createElement('a');
-      anchorEl.setAttribute('href', resultImage.src);
-      anchorEl.setAttribute('download', `${dateString} ${timeString}.jpeg`);
-      anchorEl.click();
     }
   }
 };

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -329,6 +329,10 @@ export default {
   cursor: pointer;
 }
 
+.controller-bar-button label {
+  cursor: pointer;
+}
+
 .controller-bar-button:hover {
   color: grey;
 }

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -365,7 +365,7 @@ export default {
   right: 0;
   width: 100%;
   padding: 10px 0px;
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.3);
 }
 
 .controller-bar-buttons-wrapper {

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -323,7 +323,30 @@ export default {
     },
     async done() {
       const resultImage = await this.$refs.Imoji.exportResultPhoto();
-      this.$emit('done', resultImage);
+
+      if (this.$listeners.done) {
+        this.$emit('done', resultImage);
+        return;
+      }
+
+      const d = new Date();
+      const dateString = `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(
+        2,
+        '0'
+      )}-${`${d.getDate()}`.padStart(2, '0')}`;
+
+      const timeString = `${`${d.getHours()}`.padStart(
+        2,
+        '0'
+      )}:${`${d.getMinutes()}`.padStart(2, '0')}:${`${d.getSeconds()}`.padStart(
+        2,
+        '0'
+      )}`;
+
+      const anchorEl = document.createElement('a');
+      anchorEl.setAttribute('href', resultImage.src);
+      anchorEl.setAttribute('download', `${dateString} ${timeString}.jpeg`);
+      anchorEl.click();
     }
   }
 };

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -9,7 +9,7 @@
     @off-croppable="offCroppable"
   >
     <template
-      #controllerBar="{reset, stickerCanvas, onInputImage, crop, layout, photoCanvas}"
+      #controllerBar="{reset, stickerCanvas, onInputImage, crop, layout, photoCanvas, uploadedImageSrc}"
     >
       <div class="controller-bar-wrapper">
         <button
@@ -32,7 +32,12 @@
           <cursor-move />
         </button>
 
-        <button class="controller-bar-button" title="reset" @click="reset">
+        <button
+          class="controller-bar-button"
+          title="reset"
+          :disabled="uploadedImageSrc ? false : true"
+          @click="reset"
+        >
           <restore-icon />
         </button>
 
@@ -56,7 +61,12 @@
           </button>
         </div>
 
-        <button class="controller-bar-button" title="done" @click="done">
+        <button
+          class="controller-bar-button"
+          title="done"
+          :disabled="uploadedImageSrc ? false : true"
+          @click="done"
+        >
           <download-icon />
         </button>
       </div>
@@ -337,6 +347,11 @@ export default {
   cursor: pointer;
 }
 
+.controller-bar-button:disabled {
+  color: grey;
+  cursor: not-allowed;
+}
+
 .controller-bar-button:hover {
   color: grey;
 }
@@ -384,6 +399,11 @@ export default {
   background-color: transparent;
   border-style: none;
   cursor: pointer;
+}
+
+.tool-navigation-button:disabled {
+  color: grey;
+  cursor: not-allowed;
 }
 
 .tool-navigation-button:hover {

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -85,7 +85,8 @@
             :disabled="uploadedImageSrc ? false : true"
             @click="done"
           >
-            <download-icon />
+            {{ doneLabel }}
+            <download-icon v-if="!doneLabel" />
           </button>
         </div>
       </div>
@@ -188,7 +189,7 @@
           :disabled="uploadedImageSrc ? false : true"
           @click="openImageEditor"
         >
-          Photo
+          {{ photoEditLabel }}
         </button>
 
         <button
@@ -198,7 +199,7 @@
           :disabled="uploadedImageSrc ? false : true"
           @click="openStickerEditor"
         >
-          Emoji Sticker
+          {{ stickerEditLabel }}
         </button>
       </div>
     </template>
@@ -259,6 +260,21 @@ export default {
       type: Number,
       required: false,
       default: document.documentElement.clientHeight
+    },
+    photoEditLabel: {
+      type: String,
+      required: false,
+      default: 'Photo'
+    },
+    stickerEditLabel: {
+      type: String,
+      required: false,
+      default: 'Emoji Sticker'
+    },
+    doneLabel: {
+      type: String,
+      required: false,
+      default: null
     },
     // eslint-disable-next-line vue/require-default-prop
     defaultImage: {

--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -3,6 +3,7 @@
     ref="Imoji"
     :default-image="defaultImage"
     :error-message="errorMessage"
+    :sticker-reset-message="stickerResetMessage"
     :width="width"
     :height="height"
     :is-crop-mode="isCropMode"
@@ -245,6 +246,11 @@ export default {
       type: String,
       required: false,
       default: '편집할 사진을 선택해주세요'
+    },
+    stickerResetMessage: {
+      type: String,
+      required: false,
+      default: '스티커를 초기화 하시겠습니까?'
     },
     choosePhoto: {
       type: Boolean,

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -125,15 +125,16 @@ export default {
   methods: {
     // Settings
     onImportImage() {
-      let loadImportedImage = new Promise(resolve => {
-        this.defaultImage.addEventListener(
-          'load',
-          () => {
-            resolve(this.$refs.uploadedPhoto);
-          },
-          { once: true }
+      let loadImportedImage;
+
+      if (this.defaultImage.complete) {
+        loadImportedImage = new Promise(resolve => resolve());
+      } else {
+        loadImportedImage = new Promise(resolve =>
+          this.defaultImage.addEventListener('load', resolve, { once: true })
         );
-      });
+      }
+
       loadImportedImage.then(() => {
         if (!this.photoCanvas) {
           this.photoCanvas = new PhotoEditor('#user-photo', {

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -36,30 +36,32 @@
       </div>
     </div>
     <div class="all-tool-bar-wrapper">
-      <slot
-        name="toolBar"
-        :photo-canvas="photoCanvas"
-        :layout="layout"
-        :zoom="zoom"
-        :rotate="rotate"
-        :flip="flip"
-      ></slot>
-      <slot
-        name="stickerToolBar"
-        :sticker-canvas="stickerCanvas"
-        :layout="layout"
-      ></slot>
-      <slot
-        name="ratioCropToolBar"
-        :photo-canvas="photoCanvas"
-        :layout="layout"
-      ></slot>
-      <slot
-        name="toolNavigation"
-        :open-image-editor="openImageEditor"
-        :open-sticker-editor="openStickerEditor"
-        :uploadedImageSrc="uploadedImageSrc"
-      ></slot>
+      <div class="all-tool-bar-buttons-wrapper">
+        <slot
+          name="toolBar"
+          :photo-canvas="photoCanvas"
+          :layout="layout"
+          :zoom="zoom"
+          :rotate="rotate"
+          :flip="flip"
+        ></slot>
+        <slot
+          name="stickerToolBar"
+          :sticker-canvas="stickerCanvas"
+          :layout="layout"
+        ></slot>
+        <slot
+          name="ratioCropToolBar"
+          :photo-canvas="photoCanvas"
+          :layout="layout"
+        ></slot>
+        <slot
+          name="toolNavigation"
+          :open-image-editor="openImageEditor"
+          :open-sticker-editor="openStickerEditor"
+          :uploadedImageSrc="uploadedImageSrc"
+        ></slot>
+      </div>
     </div>
   </section>
 </template>
@@ -326,7 +328,15 @@ export default {
   right: 0;
   margin: 0 auto;
   width: 100%;
-  max-width: 800px;
   background: rgba(0, 0, 0, 0.1);
+}
+
+.all-tool-bar-buttons-wrapper {
+  position: relative;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-width: 800px;
+  margin: 0 auto;
 }
 </style>

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -76,11 +76,6 @@ export default {
       type: Boolean,
       required: true
     },
-    errorMessage: {
-      type: String,
-      required: false,
-      default: '편집할 사진을 선택해주세요'
-    },
     stickerResetMessage: {
       type: String,
       required: true

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -335,7 +335,7 @@ export default {
   right: 0;
   margin: 0 auto;
   width: 100%;
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.3);
 }
 
 .all-tool-bar-buttons-wrapper {

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -320,9 +320,13 @@ export default {
 
 .all-tool-bar-wrapper {
   position: absolute;
-  bottom: 0;
-  width: 100%;
-  background: rgba(0, 0, 0, 0.1);
   z-index: 2;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 800px;
+  background: rgba(0, 0, 0, 0.1);
 }
 </style>

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -57,6 +57,7 @@
         name="toolNavigation"
         :open-image-editor="openImageEditor"
         :open-sticker-editor="openStickerEditor"
+        :uploadedImageSrc="uploadedImageSrc"
       ></slot>
     </div>
   </section>
@@ -245,22 +246,12 @@ export default {
     },
     // Tool navigation (set mode)
     openImageEditor() {
-      if (!this.uploadedImageSrc) {
-        alert(this.errorMessage);
-        throw new Error('Please pick photo.');
-      }
-
       this.hide = true;
       this.layout = 'tool-bar';
 
       this.setPhotoCanvasSize();
     },
     openStickerEditor() {
-      if (!this.uploadedImageSrc) {
-        alert(this.errorMessage);
-        throw new Error('Please pick photo.');
-      }
-
       this.$parent.$data.isCropMode = false;
       this.hide = false;
       this.layout = 'sticker-tool-bar';

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -15,6 +15,7 @@
       :layout="layout"
       :photo-canvas="photoCanvas"
       :export-result-photo="exportResultPhoto"
+      :uploadedImageSrc="uploadedImageSrc"
     >
     </slot>
 

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -81,6 +81,10 @@ export default {
       required: false,
       default: '편집할 사진을 선택해주세요'
     },
+    stickerResetMessage: {
+      type: String,
+      required: true
+    },
     width: {
       type: Number,
       required: false,
@@ -257,6 +261,14 @@ export default {
     },
     // Tool navigation (set mode)
     openImageEditor() {
+      if (this.stickerCanvas) {
+        let resetStickerCanvas = confirm(this.stickerResetMessage);
+
+        if (!resetStickerCanvas) return;
+
+        this.stickerCanvas.removeAllSticker();
+      }
+
       this.hide = true;
       this.layout = 'tool-bar';
 

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -60,6 +60,7 @@
           :open-image-editor="openImageEditor"
           :open-sticker-editor="openStickerEditor"
           :uploadedImageSrc="uploadedImageSrc"
+          :layout="layout"
         ></slot>
       </div>
     </div>


### PR DESCRIPTION
서비스에 적용하기 위해서 이것저것을 고쳤습니다.

### 변경

1. 하단 Edit, Sticker 버튼 이름 -> Photo, Emoji Sticker로 변경
  -  prop으로 변경할 수 있도록 했습니다.

2. 상단 완료 아이콘 -> prop으로 text로 대치할 수 있게 변경 

3. 사진이 없을 때, 나머지 버튼들이 클릭되지 않도록 변경 ( 기존에 사진을 추가하세요 메세지가 뜨는 대신 )
 
4. 상, 하단 바의 최대 너비를 800px 로 지정

5. 스티커 hover시 확대 효과 추가

6. 기존 아이콘 hover시 효과를 변경
-  아이콘 색이 변하던 것을 흰 배경이 나타나도록 변경

7. 기본적으로 done 이벤트 binding이 없으면 파일을 다운로드 하도록 함

8. 아이콘이 기본 색상을 가지도록 하고, 흰 배경이 나타날때 수직 정렬을 중앙으로 맞춤

9. reset 버튼, move 버튼 위치 교체

10. 사진을 직접 고르지 못하게 할 수 있는 옵션을 추가

11. 사진 편집, 스티커 편집 중 상태를 나타나게 함
-  hover 효과와 똑같이 흰 배경으로 나타나게 함

12. 스티커 편집 중 사진 편집으로 넘어가면 스티커를 모두 초기화

13. crop 중에는 완료 버튼을 숨김

14. crop이 완료돼야만 완료를 할 수 있게함 ( 13과 연관 )

### 버그

1.  이미지 업로드 버튼 마우스 hover시 cursor: pointer가 유지되지 않던 문제

2. 이미 로드된 이미지를 default-image prop으로 넣으면 제대로 작동하지 않던 문제를 해결

3. hover 효과가 PC에서만 적용되도록함