### PR TITLE
Feature/fix rotate size

### DIFF
--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -172,9 +172,7 @@ export default {
     },
     async setPhotoCanvasSize() {
       const [width, height] = await this.photoCanvas.getPhotoCanvasSize();
-
-      this.$set(this.photoCanvasSize, 0, width);
-      this.$set(this.photoCanvasSize, 1, height);
+      this.photoCanvasSize = [width, height];
       this.resizeStickerCanvas();
     },
     resizeStickerCanvas() {
@@ -197,8 +195,7 @@ export default {
       this.photoCanvas.setDragMode('none');
       this.photoCanvas.rotate(sign);
       const [width, height] = this.photoCanvas.getRotatedCanvasSize();
-      this.$set(this.photoCanvasSize, 0, width);
-      this.$set(this.photoCanvasSize, 1, height);
+      this.photoCanvasSize = [width, height];
       this.resizeStickerCanvas();
       this.clearCrop();
     },

--- a/src/components/ImojiEditorCanvas.vue
+++ b/src/components/ImojiEditorCanvas.vue
@@ -103,7 +103,8 @@ export default {
       photoCanvasSize: [0, 0],
       uploadedImageSrc: '',
       initImageSrc: '',
-      zoomCount: 0,
+      isZoomed: false,
+      isRotated: false,
       layout: '',
       hide: true,
       imgType: ''
@@ -188,15 +189,13 @@ export default {
     },
     //Tool Features
     zoom(x) {
-      this.zoomCount += x;
+      this.isZoomed = true;
       this.photoCanvas.zoom(x);
     },
     rotate(sign) {
       this.photoCanvas.setDragMode('none');
       this.photoCanvas.rotate(sign);
-      const [width, height] = this.photoCanvas.getRotatedCanvasSize();
-      this.photoCanvasSize = [width, height];
-      this.resizeStickerCanvas();
+      this.isRotated = true;
       this.clearCrop();
     },
     flip(direction) {
@@ -278,10 +277,12 @@ export default {
       }
 
       if (this.photoCanvas) {
-        if (this.zoomCount !== 0) {
+        if (this.isZoomed || this.isRotated) {
           this.crop();
-          this.zoomCount = 0;
+          this.isZoomed = false;
+          this.isRotated = false;
         }
+
         this.photoCanvas.setDragMode('none');
         this.clearCrop();
       }


### PR DESCRIPTION
### 수정사항
- 불필요한 this.$set 삭제 (커밋명에서 $set이 없어졌네요...)
- 이슈 #25 수정
- 원인 
  - 세로 또는 가로로 긴 이미지를 rotate시 width와 height가 반전됩니다.
  - 이때 rotate된 이미지는 cropper js 캔버스를 기준으로 알아서 축소되어 보이지 않습니다.
 ![스크린샷, 2021-07-21 12-58-30](https://user-images.githubusercontent.com/76927618/126428886-aa3e0253-ab70-430d-be60-388d0df680d3.png)
  - 때문에 보이는 부분에서는 캔버스를 초과하는 부분이 잘려 보이게 됩니다. (검정색으로 덮어짐) 실제 사이즈는 잘리지 않습니다.
  - 그렇게 바뀐 사이즈를 스티커 캔버스는 잘리지 않고 따라가기 때문에, 전체 에디터보다 스티커 캔버스가 길어져서 뚫고 나갑니다.
  - 결과적으로 보이는 것과 실제가 달라지기 때문에 저장시에도 차이가 있게 나옵니다.
![스크린샷, 2021-07-21 12-55-27](https://user-images.githubusercontent.com/76927618/126428986-676c88f9-97d5-4544-84de-3a6958f85f2d.png)
![imoji_2021  7  21  오후 12_55_30](https://user-images.githubusercontent.com/76927618/126428951-d6a69f80-2d94-4936-a1bb-c9f9d3834cd2.jpg)

- 해결
  - 이전에 crop지연 탓에 스티커 모드 진입시 무조건 crop되게 했던 것을, zoom 후에만 crop되게 수정한 적 있습니다. [링크](https://github.com/medistream-team/imoji-editor/pull/19)
  - cropper.js는 크롭영역이 없는데 crop하면 원본을 그대로 반환합니다. 그걸 활용해서 zoom out zoom in 된 것을 원래대로 돌려놓을 수 있었습니다.
  - rotate시에도 그 점을 활용하면 에디터의 크기 안에서 자동 설정될 것이라고 기대했고 기대한대로의 결과가 나왔습니다.
  - crop되게 하면 매우 간편하게 해결 가능하지만 지연이 조금씩 발생한다는 단점이 있습니다 😓
  - 때문에 다른 해결방법이 있다면 그쪽이 더 좋을 것 같지만 해결이 더 급한 것 같아서 PR적었습니다!
![rotate](https://user-images.githubusercontent.com/76927618/126427486-046472c1-d2e9-48da-b33f-67a4911a5d7e.gif)
![imoji_2021  7  21](https://user-images.githubusercontent.com/76927618/126427859-2030d299-0d2e-48c7-9eef-7db43cffc6ce.jpg)
