### PR TITLE
Feature/export as canvas

### DIFF
--- a/src/components/ImojiEditor.vue
+++ b/src/components/ImojiEditor.vue
@@ -360,10 +360,11 @@ export default {
     },
     async done() {
       this.doneLoading = true;
-      let resultImage;
+      let resultCanvas;
+      let imageType;
 
       try {
-        resultImage = await this.$refs.Imoji.exportResultPhoto();
+        [resultCanvas, imageType] = await this.$refs.Imoji.exportResultPhoto();
       } catch (error) {
         this.$emit('error', error);
         this.doneLoading = false;
@@ -372,14 +373,14 @@ export default {
       }
 
       if (this.$listeners.done) {
-        this.$emit('done', resultImage);
+        this.$emit('done', resultCanvas, imageType);
         this.doneLoading = false;
 
         return;
       }
 
       const anchorEl = document.createElement('a');
-      anchorEl.setAttribute('href', resultImage.src);
+      anchorEl.setAttribute('href', resultCanvas.toDataURL(imageType));
       anchorEl.setAttribute('download', `imoji_${new Date().toLocaleString()}`);
       this.doneLoading = false;
       anchorEl.click();

--- a/src/js/ImojiEditor.js
+++ b/src/js/ImojiEditor.js
@@ -141,7 +141,7 @@ export class PhotoEditor {
    * Export result photo image object when edited with sticker
    * @param {Image} stickerImage - Image Object of sticker canvas result
    * @param {string} imgType - same as original image type
-   * @returns Promise (for Image Object)
+   * @returns Promise (for [HTMLCanvasElement, imgType])
    */
   exportWithSticker(stickerImage, imgType) {
     const canvas = this.cropper.getCroppedCanvas();
@@ -150,27 +150,20 @@ export class PhotoEditor {
     const loadResultImage = new Promise(resolve => {
       stickerImage.onload = () => {
         context.drawImage(stickerImage, 0, 0);
-        resolve(canvas);
+        resolve([canvas, imgType]);
       };
     });
 
-    return loadResultImage.then(res => {
-      const withStickerImage = new Image();
-      withStickerImage.src = res.toDataURL(imgType);
-      return withStickerImage;
-    });
+    return loadResultImage;
   }
 
   /**
    * Export result photo image object when only edited
    * @param {string} imgType
-   * @returns Image Object
+   * @returns [HTMLCanvasElement, imgType]
    */
   exportOnlyImage(imgType) {
-    const canvas = this.cropper.getCroppedCanvas();
-    const editedImage = new Image();
-    editedImage.src = canvas.toDataURL(imgType);
-    return editedImage;
+    return [this.cropper.getCroppedCanvas(), imgType];
   }
 
   /**


### PR DESCRIPTION
### 편집 최종 결과물을 Canvas Element로 내보내도록 하기

-  이미지 파일 크기가 crop 후에 더 커지는 현상이 있었음
-  또, File Object로 만들어서 서버에 업로드해주고 싶은데 선택지가 없이 Image Element가 반환돼서 변환과정을 한번 더 거쳐야 하는 상황 발생
-  Canvas Element를 반환하도록 해서 blob 형식(toBlob, file object처럼도 사용 가능) , Image element 형식(toDataURL) 으로 사용할 수 있는 선택지를 열어주기
-  사용하는 쪽에서 선택 가능해지고 메소드 quality option 등도 사용 가능

### TODO
-  README.md 업데이트!